### PR TITLE
Fix mobile hero spacing and harden Resend env reads

### DIFF
--- a/apps/web/src/pages/api/invite.ts
+++ b/apps/web/src/pages/api/invite.ts
@@ -4,13 +4,20 @@ import type { APIRoute } from 'astro'
 import { Resend } from 'resend'
 import { InviteConfirmationEmail } from '../../emails/InviteConfirmationEmail'
 
-const apiKey = import.meta.env.RESEND_API_KEY
+// Read runtime env via process.env first, falling back to import.meta.env for local
+// `astro dev`. On Vercel, non-public vars referenced through import.meta.env get inlined
+// at build time and end up undefined at runtime — so process.env is the reliable source
+// for the deployed serverless functions. This is why form submissions were silently
+// hitting the "email-disabled" branch below instead of actually sending.
+const env = (key: string): string | undefined => process.env[key] ?? import.meta.env[key]
+
+const apiKey = env('RESEND_API_KEY')
 const resend = apiKey ? new Resend(apiKey) : null
 
 // Where speaking invitations land. Defaults to faris@zurichjs.com; INVITE_INBOX env
 // overrides for staging / preview environments.
-const INBOX = import.meta.env.INVITE_INBOX || 'faris@zurichjs.com'
-const FROM_EMAIL = import.meta.env.RESEND_FROM_EMAIL
+const INBOX = env('INVITE_INBOX') || 'faris@zurichjs.com'
+const FROM_EMAIL = env('RESEND_FROM_EMAIL')
 const FROM = FROM_EMAIL ? `Invite Form <${FROM_EMAIL}>` : null
 
 function esc(value: unknown): string {

--- a/apps/web/src/pages/api/mentorship.ts
+++ b/apps/web/src/pages/api/mentorship.ts
@@ -4,13 +4,20 @@ import type { APIRoute } from 'astro'
 import { Resend } from 'resend'
 import { MentorshipConfirmationEmail } from '../../emails/MentorshipConfirmationEmail'
 
-const apiKey = import.meta.env.RESEND_API_KEY
+// Read runtime env via process.env first, falling back to import.meta.env for local
+// `astro dev`. On Vercel, non-public vars referenced through import.meta.env get inlined
+// at build time and end up undefined at runtime — so process.env is the reliable source
+// for the deployed serverless functions. This is why form submissions were silently
+// hitting the "email-disabled" branch below instead of actually sending.
+const env = (key: string): string | undefined => process.env[key] ?? import.meta.env[key]
+
+const apiKey = env('RESEND_API_KEY')
 const resend = apiKey ? new Resend(apiKey) : null
 
 // Where mentorship inquiries land. Defaults to faris@zurichjs.com; MENTORSHIP_INBOX
 // (or INVITE_INBOX) env overrides for staging / preview environments.
-const INBOX = import.meta.env.MENTORSHIP_INBOX || import.meta.env.INVITE_INBOX || 'faris@zurichjs.com'
-const FROM_EMAIL = import.meta.env.RESEND_FROM_EMAIL
+const INBOX = env('MENTORSHIP_INBOX') || env('INVITE_INBOX') || 'faris@zurichjs.com'
+const FROM_EMAIL = env('RESEND_FROM_EMAIL')
 const FROM = FROM_EMAIL ? `Mentorship Inquiry <${FROM_EMAIL}>` : null
 
 function esc(value: unknown): string {

--- a/apps/web/src/pages/api/workshop/subscribe.ts
+++ b/apps/web/src/pages/api/workshop/subscribe.ts
@@ -7,13 +7,19 @@ import { GeneralSubscribeConfirmEmail } from '../../../emails/GeneralSubscribeCo
 import { sanityFetch } from '../../../lib/sanity/client'
 import { workshopInstanceBySlugQuery } from '../../../lib/sanity/queries'
 
-const GLOBAL_AUDIENCE_ID = import.meta.env.RESEND_AUDIENCE_ID
-const apiKey = import.meta.env.RESEND_API_KEY
+// Read runtime env via process.env first, falling back to import.meta.env for local
+// `astro dev`. On Vercel, non-public vars referenced through import.meta.env get inlined
+// at build time and end up undefined at runtime — so process.env is the reliable source
+// for the deployed serverless functions.
+const env = (key: string): string | undefined => process.env[key] ?? import.meta.env[key]
+
+const GLOBAL_AUDIENCE_ID = env('RESEND_AUDIENCE_ID')
+const apiKey = env('RESEND_API_KEY')
 const resend = apiKey ? new Resend(apiKey) : null
 
 // `from` address is env-driven so we don't hardcode a sender domain in source.
 // Set RESEND_FROM_EMAIL to a verified Resend sender (e.g. "noreply@yourdomain.com").
-const FROM_EMAIL = import.meta.env.RESEND_FROM_EMAIL
+const FROM_EMAIL = env('RESEND_FROM_EMAIL')
 const FROM = FROM_EMAIL ? `Faris Aziz <${FROM_EMAIL}>` : null
 
 interface WorkshopInstanceLookup {

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -232,10 +232,12 @@ const formatEventDate = (dateStr: string) => {
   <header class="hero-split-mosaic relative home-hero-v2">
     <div class="hero-split-mosaic__content">
       <div class="home-hero__content-inner">
-        <Terminal class="home-hero__terminal">
-          <div><span class="pr">$</span> <span class="cmd">whoami</span></div>
-          <div class="out">Staff Engineer & Speaker</div>
-        </Terminal>
+        <div class="home-hero__terminal">
+          <Terminal>
+            <div><span class="pr">$</span> <span class="cmd">whoami</span></div>
+            <div class="out">Staff Engineer & Speaker</div>
+          </Terminal>
+        </div>
 
         <h1 class="home-hero__title">
           <span class="ln">Faris</span>
@@ -711,9 +713,14 @@ const formatEventDate = (dateStr: string) => {
      (stacked + full-width mosaic on mobile/tablet, 38/62 split on lg+). */
   .home-hero-v2 { overflow: hidden; }
   .home-hero__content-inner { max-width: 36rem; }
+  /* Wrapper around the <Terminal> island. The spacing + width live here (not as a
+     class on <Terminal>) because Astro scoped styles don't pierce component
+     boundaries — a class passed to the component would never match this rule. */
   .home-hero__terminal {
     max-width: 300px;
-    margin-bottom: clamp(5rem, 8vw, 7rem);
+    /* Smaller gap on phones so the terminal and title aren't crammed yet still
+       breathe; grows to fill the tall two-column hero on lg+ screens. */
+    margin-bottom: clamp(2.25rem, 8vw, 7rem);
   }
   .home-hero__title {
     font-family: var(--font-display, 'Space Grotesk', system-ui, sans-serif);


### PR DESCRIPTION
Hero: the spacing/width rules for the terminal code block were defined as
scoped styles targeting a class passed to the <Terminal> component. Astro
scoped styles don't pierce component boundaries, so margin-bottom and
max-width were silently dropped and the code block sat flush against the
'Faris Aziz' title on mobile. Wrap the Terminal in a native element that the
page owns so the rules apply, and tune the gap to be generous on phones while
still filling the tall two-column hero on desktop.

Email: form endpoints read RESEND_API_KEY / RESEND_FROM_EMAIL via
import.meta.env, which Vite inlines at build time for non-public vars — on
Vercel these resolve to undefined at runtime, so submissions silently took the
'email-disabled' branch and nothing was sent. Read process.env first (the
reliable runtime source on Vercel) and fall back to import.meta.env for local
dev.