### PR TITLE
Fix Studio deploy workflow: pnpm built-in shadowed the deploy script

### DIFF
--- a/.github/workflows/deploy-studio.yml
+++ b/.github/workflows/deploy-studio.yml
@@ -37,7 +37,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Deploy Studio (build + upload)
-        run: pnpm --filter studio deploy
+        # Explicit `run` — a bare `pnpm --filter studio deploy` hits pnpm's
+        # built-in `deploy` command instead of the package script and fails
+        # with ERR_PNPM_INVALID_DEPLOY_TARGET.
+        run: pnpm --filter studio run deploy
         env:
           SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID }}
           SANITY_STUDIO_DATASET: production


### PR DESCRIPTION
## What

`deploy-studio.yml` failed with `ERR_PNPM_INVALID_DEPLOY_TARGET  This command requires one parameter`.

`pnpm --filter studio deploy` invokes **pnpm's built-in `deploy` command** (which copies a workspace package to a target directory and requires that directory as a parameter) instead of the studio package's `deploy` script (`sanity deploy`) — pnpm built-ins shadow package scripts.

## Fix

Use an explicit `run`: `pnpm --filter studio run deploy`. A comment in the workflow documents the trap for future edits.

Once the `SANITY_STUDIO_PROJECT_ID` and `SANITY_AUTH_TOKEN` repo secrets are set, merges to main touching `apps/studio/**` will auto-deploy the hosted Studio (and the workflow can be run manually from the Actions tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLfpBTk68eYd2MRkcsbJ6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLfpBTk68eYd2MRkcsbJ6z)_