### PR TITLE
Use random gallery photo as OG card avatar instead of FA monogram

### DIFF
--- a/apps/web/src/lib/og.ts
+++ b/apps/web/src/lib/og.ts
@@ -52,6 +52,27 @@ export interface OgCard {
   meta?: string;
   /** Bottom-right context label, defaults to the site domain. */
   footer?: string;
+  /** Square photo URL for the footer avatar; falls back to the "FA" monogram. */
+  avatarUrl?: string;
+}
+
+// satori can't fetch remote images itself, so pull the avatar down at build
+// time and inline it as a data URI. Cached per URL — many cards share one photo.
+const avatarCache = new Map<string, Promise<string | null>>();
+
+function loadAvatar(url: string): Promise<string | null> {
+  let cached = avatarCache.get(url);
+  if (!cached) {
+    cached = fetch(url)
+      .then(async (res) => {
+        if (!res.ok) return null;
+        const type = res.headers.get('content-type') || 'image/jpeg';
+        return `data:${type};base64,${Buffer.from(await res.arrayBuffer()).toString('base64')}`;
+      })
+      .catch(() => null);
+    avatarCache.set(url, cached);
+  }
+  return cached;
 }
 
 // satori-html does not decode HTML entities in text nodes, so escaping would
@@ -69,6 +90,10 @@ export async function renderOgCard(card: OgCard): Promise<Uint8Array<ArrayBuffer
   const title = clamp(card.title, 90);
   // Scale the headline down as it gets longer so 3 lines always fit.
   const titleSize = title.length > 60 ? 56 : title.length > 34 ? 64 : 76;
+  const avatar = card.avatarUrl ? await loadAvatar(card.avatarUrl) : null;
+  const avatarBox = avatar
+    ? `<img src="${avatar}" width="52" height="52" style="width:52px; height:52px; border-radius:12px; border:1px solid ${EDGE}; object-fit:cover;" />`
+    : `<div style="display:flex; align-items:center; justify-content:center; width:52px; height:52px; border-radius:12px; background:${ACCENT}; color:#FFFFFF; font-family:'Space Grotesk'; font-weight:700; font-size:24px;">FA</div>`;
 
   const markup = html(`
     <div style="display:flex; width:1200px; height:630px; background:${BG}; padding:24px; font-family:'Hanken Grotesk';">
@@ -93,7 +118,7 @@ export async function renderOgCard(card: OgCard): Promise<Uint8Array<ArrayBuffer
         }
         <div style="display:flex; align-items:center; justify-content:space-between; border-top:1px solid ${EDGE}; padding-top:32px;">
           <div style="display:flex; align-items:center; gap:18px;">
-            <div style="display:flex; align-items:center; justify-content:center; width:52px; height:52px; border-radius:12px; background:${ACCENT}; color:#FFFFFF; font-family:'Space Grotesk'; font-weight:700; font-size:24px;">FA</div>
+            ${avatarBox}
             <div style="display:flex; flex-direction:column;">
               <div style="display:flex; color:${INK}; font-family:'Space Grotesk'; font-weight:500; font-size:28px;">Faris Aziz</div>
               <div style="display:flex; color:${INK_FAINT}; font-size:22px;">Staff Software Engineer · Conference Speaker</div>

--- a/apps/web/src/lib/sanity/queries.ts
+++ b/apps/web/src/lib/sanity/queries.ts
@@ -330,6 +330,12 @@ export const companiesQuery = groq`
 `;
 
 // Media
+// Just the image assets — used by the OG card renderer to pick a random
+// gallery photo for the footer avatar.
+export const galleryImagesQuery = groq`
+  *[_type == "media" && type == "photo" && defined(image)].image
+`;
+
 // Every photo for the /gallery walkthrough — grouped client-side by the
 // referenced event. Photos without an event still appear (last group).
 export const galleryPhotosQuery = groq`

--- a/apps/web/src/pages/og/[...slug].png.ts
+++ b/apps/web/src/pages/og/[...slug].png.ts
@@ -1,11 +1,12 @@
 import type { APIRoute } from 'astro';
-import { sanityFetch } from '../../lib/sanity/client';
+import { sanityFetch, urlFor } from '../../lib/sanity/client';
 import {
   allTalksQuery,
   allEventsQuery,
   allBlogPostsQuery,
   allWorkshopsQuery,
   speakingStatsQuery,
+  galleryImagesQuery,
 } from '../../lib/sanity/queries';
 import { renderOgCard, OG_HEADERS, type OgCard } from '../../lib/og';
 import { FALLBACK_SPEAKER_STATS } from '../../lib/proof';
@@ -50,13 +51,32 @@ interface SpeakingStats {
 }
 
 export async function getStaticPaths() {
-  const [talks, events, posts, workshops, stats] = await Promise.all([
+  const [talks, events, posts, workshops, stats, galleryImages] = await Promise.all([
     sanityFetch<Talk[]>(allTalksQuery).catch(() => []),
     sanityFetch<EventItem[]>(allEventsQuery).catch(() => []),
     sanityFetch<BlogPost[]>(allBlogPostsQuery).catch(() => []),
     sanityFetch<Workshop[]>(allWorkshopsQuery).catch(() => []),
     sanityFetch<SpeakingStats>(speakingStatsQuery).catch(() => ({ ...FALLBACK_SPEAKER_STATS })),
+    sanityFetch<unknown[]>(galleryImagesQuery).catch(() => []),
   ]);
+
+  // Footer avatar: a random gallery photo per card, square-cropped by the
+  // Sanity CDN at 2× the rendered 52px box. Undefined → "FA" monogram fallback.
+  const randomAvatar = (): string | undefined => {
+    if (!galleryImages.length) return undefined;
+    const image = galleryImages[Math.floor(Math.random() * galleryImages.length)];
+    try {
+      return urlFor(image as Parameters<typeof urlFor>[0])
+        .width(104)
+        .height(104)
+        .fit('crop')
+        .quality(85)
+        .format('jpg')
+        .url();
+    } catch {
+      return undefined;
+    }
+  };
 
   const statLine = `${stats.totalEvents}+ talks across ${stats.countries} countries`;
 
@@ -154,7 +174,10 @@ export async function getStaticPaths() {
   };
 
   return [
-    ...Object.entries(staticCards).map(([slug, card]) => ({ params: { slug }, props: { card } })),
+    ...Object.entries(staticCards).map(([slug, card]) => ({
+      params: { slug },
+      props: { card: { ...card, avatarUrl: randomAvatar() } },
+    })),
     ...talks.map((t) => ({
       params: { slug: `talks/${t.slug}` },
       props: {
@@ -168,6 +191,7 @@ export async function getStaticPaths() {
           ]
             .filter(Boolean)
             .join(' · '),
+          avatarUrl: randomAvatar(),
         } satisfies OgCard,
       },
     })),
@@ -178,6 +202,7 @@ export async function getStaticPaths() {
           kicker: [mdDate(e.date), e.location?.isOnline ? 'Online' : e.location?.city].filter(Boolean).join(' · '),
           title: e.title,
           meta: e.conference ? `at ${e.conference}` : undefined,
+          avatarUrl: randomAvatar(),
         } satisfies OgCard,
       },
     })),
@@ -188,6 +213,7 @@ export async function getStaticPaths() {
           kicker: `Blog${p.estimatedReadingTime ? ` · ${p.estimatedReadingTime} min read` : ''}`,
           title: p.title,
           meta: mdDate(p.publishedAt),
+          avatarUrl: randomAvatar(),
         } satisfies OgCard,
       },
     })),
@@ -198,6 +224,7 @@ export async function getStaticPaths() {
           kicker: `Workshop${w.duration ? ` · ${w.duration}` : ''}${w.level ? ` · ${w.level}` : ''}`,
           title: w.title,
           meta: 'Hands-on training — bookable for teams & conferences.',
+          avatarUrl: randomAvatar(),
         } satisfies OgCard,
       },
     })),


### PR DESCRIPTION
Each OG card's footer avatar now shows a random gallery photo, picked at
build time from Sanity media docs and square-cropped by the image CDN.
The photo is inlined as a data URI since satori can't fetch remote
images; the FA monogram remains as the fallback when the gallery is
empty or the fetch fails.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011iy3VExJroB8oTmkWF5Mkt