### PR TITLE
Enhance PostHog: identify users, gated session recording, richer events

### DIFF
--- a/apps/web/src/components/islands/CommandPalette.tsx
+++ b/apps/web/src/components/islands/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { navigate } from 'astro:transitions/client';
+import { track } from '../../lib/analytics';
 
 type Cmd =
   | { group: string; label: string; icon: string; href: string; external?: boolean; keyHint?: string }
@@ -67,6 +68,7 @@ export default function CommandPalette() {
   useEffect(() => {
     if (!open) return;
     try { setRecentLabel(localStorage.getItem(RECENT_KEY)); } catch (_) {}
+    track('command_palette_opened', { path: window.location.pathname });
   }, [open]);
 
   const filtered = useMemo(() => {
@@ -119,6 +121,11 @@ export default function CommandPalette() {
 
   function run(cmd: Cmd) {
     try { localStorage.setItem(RECENT_KEY, cmd.label); } catch (_) {}
+    track('command_palette_action', {
+      command: cmd.label,
+      group: cmd.group,
+      href: 'href' in cmd ? cmd.href : undefined,
+    });
     if ('action' in cmd && cmd.action === 'copy') {
       try {
         navigator.clipboard?.writeText(cmd.text);

--- a/apps/web/src/components/islands/ContactForm.tsx
+++ b/apps/web/src/components/islands/ContactForm.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type FormEvent } from 'react';
+import { identify, track, trackFormStarted } from '../../lib/analytics';
 
 type Topic = 'role' | 'speaking' | 'consulting' | 'mentorship' | 'other';
 
@@ -56,6 +57,7 @@ export default function ContactForm() {
   }, []);
 
   function set<K extends keyof Fields>(key: K, value: Fields[K]) {
+    trackFormStarted('contact');
     setFields((f) => ({ ...f, [key]: value }));
     if (errors[key]) setErrors((e) => { const { [key]: _, ...rest } = e; return rest; });
   }
@@ -67,7 +69,10 @@ export default function ContactForm() {
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(fields.email.trim())) next.email = true;
     if (!fields.message.trim()) next.message = true;
     setErrors(next);
-    if (Object.keys(next).length > 0) return;
+    if (Object.keys(next).length > 0) {
+      track('form_validation_failed', { form: 'contact', fields: Object.keys(next) });
+      return;
+    }
 
     setSubmitting(true);
     setServerError(null);
@@ -80,12 +85,23 @@ export default function ContactForm() {
       const body = (await res.json().catch(() => ({}))) as { error?: string };
       if (!res.ok) {
         setServerError(body.error || 'Something went wrong — try again in a moment.');
+        track('form_submit_failed', { form: 'contact', reason: 'server', status: res.status });
         return;
       }
       setSuccess(true);
-      try { (window as any).posthog?.capture('contact_form_submitted', { topic: fields.topic }); } catch (_) {}
+      identify(fields.email, {
+        name: fields.name.trim(),
+        company: fields.company.trim() || undefined,
+        last_contact_topic: fields.topic,
+      });
+      track('contact_form_submitted', {
+        topic: fields.topic,
+        has_company: Boolean(fields.company.trim()),
+        message_length: fields.message.trim().length,
+      });
     } catch (err) {
       setServerError("Couldn't reach the server. Try again in a moment.");
+      track('form_submit_failed', { form: 'contact', reason: 'network' });
     } finally {
       setSubmitting(false);
     }

--- a/apps/web/src/components/islands/GeneralSubscribe.tsx
+++ b/apps/web/src/components/islands/GeneralSubscribe.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { identify, track } from '../../lib/analytics';
 
 interface Props {
   compact?: boolean;
@@ -23,8 +24,11 @@ export default function GeneralSubscribe({ compact = false }: Props) {
 
       if (!res.ok) throw new Error('Failed');
       setStatus('success');
+      identify(email, { newsletter_subscriber: true });
+      track('newsletter_subscribed', { source: 'website', placement: compact ? 'compact' : 'card' });
     } catch {
       setStatus('error');
+      track('form_submit_failed', { form: 'newsletter', reason: 'server' });
     }
   };
 

--- a/apps/web/src/components/islands/HeroTerminal.tsx
+++ b/apps/web/src/components/islands/HeroTerminal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { navigate } from 'astro:transitions/client';
+import { track } from '../../lib/analytics';
 
 /**
  * The hero terminal, made real. Renders exactly like the old static
@@ -102,6 +103,11 @@ export default function HeroTerminal({ name = 'faris.sh', mode = 'hero' }: Props
     print({ kind: 'cmd', text: cmdLine });
 
     const [cmd, ...args] = cmdLine.toLowerCase().split(/\s+/);
+    track('terminal_command', {
+      command: cmd.slice(0, 24),
+      known: COMMAND_NAMES.includes(cmd) || ['sudo', 'konami', 'coffee', 'exit', 'hire-me', 'hiring'].includes(cmd),
+      mode,
+    });
 
     if (cmd === 'clear') {
       setLines([]);

--- a/apps/web/src/components/islands/InviteForm.tsx
+++ b/apps/web/src/components/islands/InviteForm.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type FormEvent } from 'react';
+import { identify, track, trackFormStarted } from '../../lib/analytics';
 
 type Format = 'keynote' | 'talk' | 'workshop' | 'panel';
 type Size = 's' | 'm' | 'l' | 'xl';
@@ -57,6 +58,7 @@ export default function InviteForm() {
   }, []);
 
   function set<K extends keyof Fields>(key: K, value: Fields[K]) {
+    trackFormStarted('invite');
     setFields((f) => ({ ...f, [key]: value }));
     if (errors[key]) setErrors((e) => { const { [key]: _, ...rest } = e; return rest; });
   }
@@ -68,7 +70,10 @@ export default function InviteForm() {
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(fields.email.trim())) next.email = true;
     if (!fields.event.trim()) next.event = true;
     setErrors(next);
-    if (Object.keys(next).length > 0) return;
+    if (Object.keys(next).length > 0) {
+      track('form_validation_failed', { form: 'invite', fields: Object.keys(next) });
+      return;
+    }
 
     setSubmitting(true);
     setServerError(null);
@@ -81,12 +86,24 @@ export default function InviteForm() {
       const body = (await res.json().catch(() => ({}))) as { error?: string };
       if (!res.ok) {
         setServerError(body.error || 'Something went wrong — try emailing instead.');
+        track('form_submit_failed', { form: 'invite', reason: 'server', status: res.status });
         return;
       }
       setSuccess(true);
-      try { (window as any).posthog?.capture('invite_form_submitted', { format: fields.format }); } catch (_) {}
+      identify(fields.email, {
+        name: fields.name.trim(),
+        last_invite_event: fields.event.trim(),
+      });
+      track('invite_form_submitted', {
+        format: fields.format,
+        audience_size: fields.size,
+        event: fields.event.trim(),
+        has_date: Boolean(fields.date),
+        has_location: Boolean(fields.location.trim()),
+      });
     } catch (err) {
       setServerError("Couldn't reach the server. Try again in a moment.");
+      track('form_submit_failed', { form: 'invite', reason: 'network' });
     } finally {
       setSubmitting(false);
     }

--- a/apps/web/src/components/islands/MentorshipInquiryForm.tsx
+++ b/apps/web/src/components/islands/MentorshipInquiryForm.tsx
@@ -1,4 +1,5 @@
 import { useState, type FormEvent } from 'react';
+import { identify, track, trackFormStarted } from '../../lib/analytics';
 
 type Currency = 'chf' | 'eur' | 'usd';
 type BudgetTier = 's' | 'm' | 'l' | 'xl' | 'flex';
@@ -41,6 +42,7 @@ export default function MentorshipInquiryForm() {
   const [serverError, setServerError] = useState<string | null>(null);
 
   function set<K extends keyof Fields>(key: K, value: Fields[K]) {
+    trackFormStarted('mentorship');
     setFields((f) => ({ ...f, [key]: value }));
     if (errors[key]) setErrors((e) => { const { [key]: _omit, ...rest } = e; return rest; });
   }
@@ -52,7 +54,10 @@ export default function MentorshipInquiryForm() {
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(fields.email.trim())) next.email = true;
     if (!fields.goals.trim()) next.goals = true;
     setErrors(next);
-    if (Object.keys(next).length > 0) return;
+    if (Object.keys(next).length > 0) {
+      track('form_validation_failed', { form: 'mentorship', fields: Object.keys(next) });
+      return;
+    }
 
     setSubmitting(true);
     setServerError(null);
@@ -65,12 +70,20 @@ export default function MentorshipInquiryForm() {
       const body = (await res.json().catch(() => ({}))) as { error?: string };
       if (!res.ok) {
         setServerError(body.error || 'Something went wrong — try emailing instead.');
+        track('form_submit_failed', { form: 'mentorship', reason: 'server', status: res.status });
         return;
       }
       setSuccess(true);
-      try { (window as any).posthog?.capture('mentorship_inquiry_submitted'); } catch (_) {}
+      identify(fields.email, { name: fields.name.trim() });
+      track('mentorship_inquiry_submitted', {
+        budget: fields.budget,
+        currency: fields.currency,
+        timeline: fields.timeline,
+        cadence: fields.cadence,
+      });
     } catch (_err) {
       setServerError("Couldn't reach the server. Try again in a moment.");
+      track('form_submit_failed', { form: 'mentorship', reason: 'network' });
     } finally {
       setSubmitting(false);
     }

--- a/apps/web/src/components/islands/WorkshopAttend.tsx
+++ b/apps/web/src/components/islands/WorkshopAttend.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { identify, track } from '../../lib/analytics';
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -513,9 +514,12 @@ function GateView({
 
       const user = { name: name.trim(), email };
       storeUser(token, user);
+      identify(email, { name: name.trim(), workshop_attendee: true });
+      track('workshop_signed_up', { workshop: event, instance: token });
       onSuccess(user);
     } catch {
       setStatus('error');
+      track('form_submit_failed', { form: 'workshop-attend', reason: 'server' });
     }
   };
 

--- a/apps/web/src/components/posthog.astro
+++ b/apps/web/src/components/posthog.astro
@@ -1,7 +1,24 @@
 ---
 // src/components/posthog.astro
+//
+// The entire client-side analytics layer lives here:
+//   1. PostHog loader snippet + init (person profiles for identified users,
+//      pageleave, dead clicks, exception capture, heatmaps via defaults).
+//   2. Session recording, armed but only *started* on conversion pages
+//      (docs/measurement.md) — once started it runs for the rest of the session.
+//   3. Sitewide auto-events: cta_click ([data-track]), outbound_link_click,
+//      scroll_depth milestones.
+//
+// React islands emit their own events via src/lib/analytics.ts. Event
+// vocabulary is documented in docs/measurement.md — keep it in sync.
+//
+// Key/host are overridable per-environment; the fallbacks are the production
+// EU project so the site keeps measuring even if the env vars are missing.
+const POSTHOG_KEY = import.meta.env.PUBLIC_POSTHOG_KEY || 'phc_XVJoOg4MSdLDEGn0wf9uzSOi1cg0Hz6PstGzNsFyU0r';
+const POSTHOG_HOST = import.meta.env.PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com';
 ---
-<script is:inline type="text/javascript" id="posthog-js">
+<script is:inline define:vars={{ POSTHOG_KEY, POSTHOG_HOST }}>
+  // --- Official PostHog loader stub (queues calls until array.js arrives) ---
   !(function(t, e) {
     var o, n, p, r;
     e.__SV ||
@@ -31,7 +48,7 @@
           return u.toString(1) + '.people (stub)';
         };
         o =
-          'capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId'.split(
+          'init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric people.set people.set_once'.split(
             ' '
           );
         for (n = 0; n < o.length; n++) g(u, o[n]);
@@ -39,5 +56,137 @@
       }),
       (e.__SV = 1));
   })(document, window.posthog || []);
-  posthog.init('phc_XVJoOg4MSdLDEGn0wf9uzSOi1cg0Hz6PstGzNsFyU0r', { api_host: 'https://eu.i.posthog.com', defaults: '2025-05-24' });
+
+  (function () {
+    // Local dev never pollutes production analytics.
+    var isDev = /^(localhost|127\.0\.0\.1|\[::1\])$/.test(location.hostname);
+    if (isDev) {
+      console.debug('[posthog] disabled on ' + location.hostname);
+      return;
+    }
+
+    posthog.init(POSTHOG_KEY, {
+      api_host: POSTHOG_HOST,
+      // 2025-05-24 defaults: history_change pageviews (covers Astro
+      // ViewTransitions), heatmaps, rageclicks, sane autocapture.
+      defaults: '2025-05-24',
+      // Person profiles only for people we identify() (form submitters);
+      // anonymous traffic stays event-only and cheap.
+      person_profiles: 'identified_only',
+      capture_pageleave: true,
+      capture_dead_clicks: true,
+      // Client-side error tracking (PostHog "Error tracking" product).
+      capture_exceptions: true,
+      // Recording is opt-in per page: armed here, started by the gate below.
+      disable_session_recording: true,
+      session_recording: {
+        maskAllInputs: true,
+        maskTextSelector: '[data-ph-mask]',
+      },
+      loaded: function (ph) {
+        // Super-property on every event: which theme the visitor browses in.
+        ph.register({
+          theme: document.documentElement.getAttribute('data-theme') || 'dark',
+        });
+      },
+    });
+
+    window.addEventListener('themechange', function (e) {
+      try { posthog.register({ theme: (e.detail && e.detail.theme) || 'dark' }); } catch (_) {}
+    });
+
+    // --- Session recording gate ---------------------------------------------
+    // Record only sessions that touch a conversion page (docs/measurement.md):
+    // that's where watching friction pays off. startSessionRecording() is
+    // sticky, so a session that lands on /contact keeps recording afterwards.
+    var RECORD_PATHS = ['/invite', '/contact', '/consulting', '/mentorship'];
+    function maybeRecord() {
+      var p = location.pathname;
+      var hit = RECORD_PATHS.some(function (pre) {
+        return p === pre || p.indexOf(pre + '/') === 0;
+      });
+      if (hit) {
+        try { posthog.startSessionRecording(); } catch (_) {}
+      }
+    }
+    maybeRecord();
+    document.addEventListener('astro:after-swap', maybeRecord);
+
+    // --- Early identify: the moment an email lands in any field ---------------
+    // Blurring any input[type=email] with a valid address identifies the
+    // visitor right away — no need to finish the form. The submit-time
+    // identify() calls in the islands then enrich the same person (name,
+    // company, …). Also fires email_entered so "gave email but never
+    // submitted" is a queryable funnel step.
+    var lastIdentifiedEmail = null;
+    document.addEventListener('focusout', function (e) {
+      var el = e.target;
+      if (!el || el.tagName !== 'INPUT') return;
+      if (el.type !== 'email' && el.getAttribute('autocomplete') !== 'email') return;
+      var v = (el.value || '').trim().toLowerCase();
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v) || v === lastIdentifiedEmail) return;
+      lastIdentifiedEmail = v;
+      try {
+        posthog.identify(v, { email: v });
+        posthog.capture('email_entered', { path: location.pathname, field: el.id || el.name || undefined });
+      } catch (_) {}
+    });
+
+    // --- cta_click: any element with data-track ------------------------------
+    // One document-level listener — survives ViewTransitions swaps.
+    document.addEventListener('click', function (e) {
+      var el = e.target && e.target.closest ? e.target.closest('[data-track]') : null;
+      if (!el) return;
+      posthog.capture('cta_click', {
+        cta: el.getAttribute('data-track'),
+        label: el.getAttribute('data-track-label') || (el.textContent || '').trim().slice(0, 60),
+        href: el.getAttribute('href') || undefined,
+        path: location.pathname,
+      });
+    });
+
+    // --- outbound_link_click --------------------------------------------------
+    // cal.com is excluded: those clicks already fire discovery_call_opened.
+    document.addEventListener('click', function (e) {
+      var a = e.target && e.target.closest ? e.target.closest('a[href]') : null;
+      if (!a) return;
+      var u;
+      try { u = new URL(a.href, location.href); } catch (_) { return; }
+      if (u.protocol !== 'https:' && u.protocol !== 'http:') return;
+      if (u.hostname === location.hostname) return;
+      if (u.hostname === 'cal.com' || u.hostname.slice(-8) === '.cal.com') return;
+      posthog.capture('outbound_link_click', {
+        href: u.href,
+        domain: u.hostname,
+        label: (a.textContent || '').trim().slice(0, 60) || a.getAttribute('aria-label') || undefined,
+        path: location.pathname,
+      });
+    });
+
+    // --- scroll_depth ----------------------------------------------------------
+    // 25/50/75/100 milestones, each fired once per pageview. Resets on
+    // ViewTransitions navigation. rAF-throttled passive listener.
+    var MILESTONES = [25, 50, 75, 100];
+    var fired = {};
+    var ticking = false;
+    function resetDepth() { fired = {}; }
+    function measureDepth() {
+      ticking = false;
+      var doc = document.documentElement;
+      var scrollable = doc.scrollHeight - window.innerHeight;
+      if (scrollable <= 0) return;
+      var pct = Math.min(100, Math.round(((window.scrollY || doc.scrollTop || 0) / scrollable) * 100));
+      for (var i = 0; i < MILESTONES.length; i++) {
+        var m = MILESTONES[i];
+        if (pct >= m && !fired[m]) {
+          fired[m] = true;
+          posthog.capture('scroll_depth', { depth: m, path: location.pathname });
+        }
+      }
+    }
+    window.addEventListener('scroll', function () {
+      if (!ticking) { ticking = true; window.requestAnimationFrame(measureDepth); }
+    }, { passive: true });
+    document.addEventListener('astro:after-swap', resetDepth);
+  })();
 </script>

--- a/apps/web/src/components/posthog.astro
+++ b/apps/web/src/components/posthog.astro
@@ -12,9 +12,10 @@
 // React islands emit their own events via src/lib/analytics.ts. Event
 // vocabulary is documented in docs/measurement.md — keep it in sync.
 //
-// Key/host are overridable per-environment; the fallbacks are the production
-// EU project so the site keeps measuring even if the env vars are missing.
-const POSTHOG_KEY = import.meta.env.PUBLIC_POSTHOG_KEY || 'phc_XVJoOg4MSdLDEGn0wf9uzSOi1cg0Hz6PstGzNsFyU0r';
+// The key comes exclusively from the environment — never hardcode it here.
+// Set PUBLIC_POSTHOG_KEY in Vercel (Production + Preview) and .env.local for
+// dev; without it, analytics is silently off. Host defaults to the EU cloud.
+const POSTHOG_KEY = import.meta.env.PUBLIC_POSTHOG_KEY || '';
 const POSTHOG_HOST = import.meta.env.PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com';
 ---
 <script is:inline define:vars={{ POSTHOG_KEY, POSTHOG_HOST }}>
@@ -58,6 +59,10 @@ const POSTHOG_HOST = import.meta.env.PUBLIC_POSTHOG_HOST || 'https://eu.i.postho
   })(document, window.posthog || []);
 
   (function () {
+    if (!POSTHOG_KEY) {
+      console.debug('[posthog] PUBLIC_POSTHOG_KEY not set — analytics disabled');
+      return;
+    }
     // Local dev never pollutes production analytics.
     var isDev = /^(localhost|127\.0\.0\.1|\[::1\])$/.test(location.hostname);
     if (isDev) {

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -5,7 +5,7 @@ interface ImportMetaEnv {
   readonly SANITY_STUDIO_DATASET: string;
   readonly SANITY_API_TOKEN: string;
   readonly PROD: boolean;
-  /** PostHog project API key; falls back to the production EU project. */
+  /** PostHog project API key; analytics is disabled when unset. */
   readonly PUBLIC_POSTHOG_KEY?: string;
   /** PostHog ingestion host; defaults to https://eu.i.posthog.com. */
   readonly PUBLIC_POSTHOG_HOST?: string;

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -5,6 +5,10 @@ interface ImportMetaEnv {
   readonly SANITY_STUDIO_DATASET: string;
   readonly SANITY_API_TOKEN: string;
   readonly PROD: boolean;
+  /** PostHog project API key; falls back to the production EU project. */
+  readonly PUBLIC_POSTHOG_KEY?: string;
+  /** PostHog ingestion host; defaults to https://eu.i.posthog.com. */
+  readonly PUBLIC_POSTHOG_HOST?: string;
 }
 
 interface ImportMeta {

--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -124,7 +124,9 @@ const {
 
     <ViewTransitions />
 
-    <!-- Analytics -->
+    <!-- Analytics: loader + init + sitewide auto-events (cta_click, outbound
+         links, scroll depth, session-recording gate) all live in posthog.astro.
+         Islands emit their own events via src/lib/analytics.ts. -->
     <PostHog />
 
     <!-- Theme: dark by default; a stored preference wins. Sets both `.dark` (Tailwind) and `data-theme` (DS v2).
@@ -209,21 +211,6 @@ const {
           }, 2500);
         });
       })();
-    </script>
-
-    <!-- Funnel analytics: any element with data-track fires a cta_click event.
-         One document-level listener — survives ViewTransitions swaps. -->
-    <script is:inline>
-      document.addEventListener('click', function (e) {
-        var el = e.target && e.target.closest ? e.target.closest('[data-track]') : null;
-        if (!el || !window.posthog) return;
-        window.posthog.capture('cta_click', {
-          cta: el.getAttribute('data-track'),
-          label: el.getAttribute('data-track-label') || (el.textContent || '').trim().slice(0, 60),
-          href: el.getAttribute('href') || undefined,
-          path: location.pathname,
-        });
-      });
     </script>
 
     <!-- Scroll-reveal (.ds-reveal, see docs/ui-rules.md): the single sitewide

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,0 +1,80 @@
+/**
+ * Client-side PostHog helper for React islands.
+ *
+ * PostHog is loaded by `components/posthog.astro` (inline snippet on every
+ * page); islands never import posthog-js directly — they call these wrappers,
+ * which no-op safely when the script is blocked or still loading. Keep the
+ * event names here in sync with docs/measurement.md.
+ */
+
+/** Known custom events — one place to see the whole vocabulary. */
+export type AnalyticsEvent =
+  | 'cta_click'
+  | 'invite_form_submitted'
+  | 'mentorship_inquiry_submitted'
+  | 'contact_form_submitted'
+  | 'newsletter_subscribed'
+  | 'workshop_signed_up'
+  | 'discovery_call_opened'
+  | 'email_entered'
+  | 'form_started'
+  | 'form_validation_failed'
+  | 'form_submit_failed'
+  | 'scroll_depth'
+  | 'outbound_link_click'
+  | 'terminal_command'
+  | 'command_palette_opened'
+  | 'command_palette_action';
+
+type Props = Record<string, unknown>;
+
+function ph(): any | undefined {
+  return typeof window !== 'undefined' ? (window as any).posthog : undefined;
+}
+
+/** Capture a custom event. Never throws. */
+export function track(event: AnalyticsEvent, props?: Props): void {
+  try {
+    ph()?.capture(event, props);
+  } catch (_) {
+    /* analytics must never break the UI */
+  }
+}
+
+/**
+ * Tie the current anonymous session to a real person. Call at the moment we
+ * actually learn who they are (form success), never speculatively.
+ *
+ * Uses the lowercased email as the distinct ID so the same person converges
+ * across devices/forms; extra props become person properties ($set).
+ */
+export function identify(email: string, props?: Props): void {
+  try {
+    const id = email.trim().toLowerCase();
+    if (!id) return;
+    ph()?.identify(id, { email: id, ...props });
+  } catch (_) {
+    /* noop */
+  }
+}
+
+/** Person properties that should only ever be written once (first-touch). */
+export function setPersonPropsOnce(props: Props): void {
+  try {
+    ph()?.setPersonProperties({}, props);
+  } catch (_) {
+    /* noop */
+  }
+}
+
+const startedForms = new Set<string>();
+
+/**
+ * Fire `form_started` the first time a visitor touches a given form (per
+ * page lifetime). Pairs with the `*_submitted` events to measure abandonment.
+ */
+export function trackFormStarted(form: string): void {
+  if (startedForms.has(form)) return;
+  startedForms.add(form);
+  track('form_started', { form });
+}

--- a/docs/measurement.md
+++ b/docs/measurement.md
@@ -4,34 +4,105 @@ The site emits a small, deliberate set of PostHog events. This doc is the
 single reference for what fires where, and the funnels/insights worth building
 in the PostHog UI (they can't be created from code).
 
+## Architecture
+
+- `apps/web/src/components/posthog.astro` — loader, init config, session-recording
+  gate, and the sitewide auto-events (`cta_click`, `outbound_link_click`,
+  `scroll_depth`).
+- `apps/web/src/lib/analytics.ts` — typed `track()` / `identify()` /
+  `trackFormStarted()` wrappers used by React islands. The `AnalyticsEvent`
+  union there is the canonical event list; keep it in sync with this doc.
+- Key/host come from `PUBLIC_POSTHOG_KEY` / `PUBLIC_POSTHOG_HOST` env vars,
+  falling back to the production EU project. Capture is disabled on
+  `localhost` so dev never pollutes prod data.
+
+### Init config highlights
+
+- `defaults: '2025-05-24'` — history-change pageviews (works with Astro
+  ViewTransitions), autocapture, heatmaps, rageclicks.
+- `person_profiles: 'identified_only'` — anonymous visitors are event-only
+  (cheaper); a person profile is created the moment a form identifies them.
+- `capture_pageleave`, `capture_dead_clicks`, `capture_exceptions` (error
+  tracking) are on.
+- Super-property `theme` (`dark`/`light`) is registered on every event and
+  updated on the `themechange` custom event.
+
+## Identify
+
+Identification happens at two moments:
+
+1. **As soon as an email is entered.** A document-level `focusout` listener in
+   `posthog.astro` watches every `input[type="email"]` sitewide: blur a field
+   containing a valid address and the visitor is identified immediately (and
+   `email_entered` fires) — even if they abandon the form one field later.
+2. **On successful submit.** The islands call `identify(email, props)` again
+   to enrich the same person with what the form learned: `name`, plus
+   form-specific props (`company`, `last_contact_topic`, `last_invite_event`,
+   `newsletter_subscriber`, `workshop_attendee`).
+
+The lowercased email is the distinct ID in both cases, so the same person
+converges across devices, forms, and visits.
+
+## Session recording
+
+Recording is initialized **disabled** and started only when a pageview hits a
+conversion page: `/invite`, `/contact`, `/consulting`, `/mentorship` (path or
+sub-path). Once started it keeps recording for the rest of the session, so you
+see what happens *after* the conversion page too. All inputs are masked
+(`maskAllInputs: true`); mask any other sensitive element with a
+`data-ph-mask` attribute. To record site-wide, edit `RECORD_PATHS` in
+`posthog.astro` (and remember recording must also be enabled in the PostHog
+project settings).
+
 ## Events
 
 | Event | Fires when | Properties |
 |---|---|---|
-| `cta_click` | Any element with `data-track` is clicked (document-level listener in `BaseLayout`) | `cta` (slug, e.g. `header-cta`, `contact-door`, `contact-panel-primary`, `talk-stickybar`, `megamenu-invite`, `megamenu-discovery-call`), `label`, `href`, `path` |
-| `invite_form_submitted` | Speaker invite form success (`/invite`) | `format` |
-| `mentorship_inquiry_submitted` | Mentorship inquiry success (`/mentorship`) | — |
-| `contact_form_submitted` | General contact form success (`/contact`) | `topic` (`role` / `speaking` / `consulting` / `mentorship` / `other`) |
+| `cta_click` | Any element with `data-track` is clicked (document-level listener) | `cta` (slug, e.g. `header-cta`, `contact-door`, `contact-panel-primary`, `talk-stickybar`, `megamenu-invite`, `megamenu-discovery-call`), `label`, `href`, `path` |
+| `invite_form_submitted` | Speaker invite form success (`/invite`) | `format`, `audience_size`, `event`, `has_date`, `has_location` |
+| `mentorship_inquiry_submitted` | Mentorship inquiry success (`/mentorship`) | `budget`, `currency`, `timeline`, `cadence` |
+| `contact_form_submitted` | General contact form success (`/contact`) | `topic` (`role` / `speaking` / `consulting` / `mentorship` / `other`), `has_company`, `message_length` |
+| `newsletter_subscribed` | Conference-schedule subscribe success | `source`, `placement` (`compact` / `card`) |
+| `workshop_signed_up` | Workshop attend gate completed | `workshop`, `instance` |
 | `discovery_call_opened` | A cal.com link opened as the on-site modal | `path` |
-| `$pageview` etc. | PostHog defaults | — |
+| `email_entered` | A valid email is blurred in any email field (also identifies the visitor) | `path`, `field` |
+| `form_started` | First interaction with a form (once per page lifetime) | `form` (`contact` / `invite` / `mentorship`) |
+| `form_validation_failed` | Client-side validation blocked a submit | `form`, `fields` (which failed) |
+| `form_submit_failed` | Server error or network failure on submit | `form`, `reason` (`server` / `network`), `status` |
+| `scroll_depth` | 25/50/75/100% scroll milestones, once per pageview | `depth`, `path` |
+| `outbound_link_click` | Click on an external link (cal.com excluded) | `href`, `domain`, `label`, `path` |
+| `terminal_command` | A command is executed in the hero/404 terminal | `command`, `known`, `mode` |
+| `command_palette_opened` | ⌘K palette opened | `path` |
+| `command_palette_action` | A palette command is run | `command`, `group`, `href` |
+| `$pageview`, `$pageleave`, `$autocapture`, `$exception`, … | PostHog defaults | — |
 
 ## Funnels to build (PostHog UI)
 
-1. **Speaking:** `$pageview` (any) → `cta_click` where `cta ∈ {header-cta, megamenu-invite, contact-panel-primary, talk-stickybar}` → `$pageview` of `/invite` → `invite_form_submitted`. Break down by first-touch `path` and by referrer.
+1. **Speaking:** `$pageview` (any) → `cta_click` where `cta ∈ {header-cta, megamenu-invite, contact-panel-primary, talk-stickybar}` → `$pageview` of `/invite` → `form_started` (`form=invite`) → `invite_form_submitted`. Break down by first-touch `path` and by referrer.
 2. **Consulting:** `$pageview` of `/consulting` or `/services` → `discovery_call_opened`. (The booking itself completes inside cal.com — reconcile counts against cal.com's dashboard monthly.)
-3. **Mentorship:** `$pageview` of `/mentorship` → `mentorship_inquiry_submitted`.
-4. **Hiring / general:** `cta_click` where `cta = contact-door` (breakdown by `label`) → `contact_form_submitted` (breakdown by `topic`).
+3. **Mentorship:** `$pageview` of `/mentorship` → `form_started` (`form=mentorship`) → `mentorship_inquiry_submitted`.
+4. **Hiring / general:** `cta_click` where `cta = contact-door` (breakdown by `label`) → `form_started` (`form=contact`) → `contact_form_submitted` (breakdown by `topic`).
+
+The `form_started` step is the abandonment probe: a big drop between
+`form_started` and `*_submitted` means friction inside the form — go watch
+the session recordings for that page.
 
 ## Insights worth pinning
 
 - `cta_click` breakdown by `cta` — which surfaces actually drive action (mega-menu vs footer vs panels vs sticky bar vs terminal-adjacent CTAs).
 - `contact_form_submitted` by `topic` over time — is the full-time-role door pulling?
+- `form_validation_failed` by `fields` — a recurring field points at confusing copy or layout.
+- `email_entered` with no `*_submitted` in the same session — identified warm leads who bailed mid-form; the session recording shows why.
+- `scroll_depth` ≥75 on `/talks`, `/consulting`, `/mentorship` — is the long-form content read or skipped?
+- `outbound_link_click` by `domain` — where the site leaks attention (GitHub, LinkedIn, YouTube…).
+- `terminal_command` where `known = false` — what people *try* to type is a feature wishlist.
 - Referrer breakdown filtered to AI surfaces (`chatgpt.com`, `perplexity.ai`, `claude.ai`, `copilot.microsoft.com`) — low volume, disproportionate intent; watch conversion rate per source.
-- Session recordings: enable **only** for `/invite`, `/contact`, `/consulting`, `/mentorship` (conversion pages), and watch a handful weekly for friction.
+- Session recordings on `/invite`, `/contact`, `/consulting`, `/mentorship` (the gate only records these) — watch a handful weekly for friction.
+- Error tracking (`$exception`) — a spike after a deploy is a regression on a real visitor's browser.
 
 ## Cadence
 
 Review funnels ~4 weeks after deploy, then monthly. Let the data pick the next
 experiment (e.g. door copy variants, form field order) instead of intuition.
 The events are intentionally few — add a new one only when a decision depends
-on it, and document it here.
+on it, add it to `AnalyticsEvent` in `lib/analytics.ts`, and document it here.

--- a/docs/measurement.md
+++ b/docs/measurement.md
@@ -12,8 +12,10 @@ in the PostHog UI (they can't be created from code).
 - `apps/web/src/lib/analytics.ts` — typed `track()` / `identify()` /
   `trackFormStarted()` wrappers used by React islands. The `AnalyticsEvent`
   union there is the canonical event list; keep it in sync with this doc.
-- Key/host come from `PUBLIC_POSTHOG_KEY` / `PUBLIC_POSTHOG_HOST` env vars,
-  falling back to the production EU project. Capture is disabled on
+- Key/host come from `PUBLIC_POSTHOG_KEY` / `PUBLIC_POSTHOG_HOST` env vars
+  (host defaults to the EU cloud). The key is never hardcoded — when
+  `PUBLIC_POSTHOG_KEY` is unset, analytics is silently disabled, so it must be
+  set in Vercel on **Production and Preview**. Capture is also disabled on
   `localhost` so dev never pollutes prod data.
 
 ### Init config highlights


### PR DESCRIPTION
- posthog.astro becomes the whole client analytics layer: env-overridable
  key/host (PUBLIC_POSTHOG_KEY/HOST), identified_only person profiles,
  pageleave/dead-click/exception capture, theme super-property, and a
  localhost guard so dev traffic never hits prod.
- Session recording armed but only started on conversion pages
  (/invite, /contact, /consulting, /mentorship) per docs/measurement.md,
  with all inputs masked and a data-ph-mask escape hatch.
- Identify on first email entry: a sitewide focusout listener on
  input[type=email] identifies the visitor (and fires email_entered) the
  moment a valid address is blurred — before the form is submitted.
- New lib/analytics.ts: typed track()/identify()/trackFormStarted()
  wrappers for islands; all forms migrate off raw window.posthog.
- Form funnel events on every form: form_started, form_validation_failed,
  form_submit_failed, plus richer submit props; success handlers also
  identify() with name/company/etc.
- New engagement events: scroll_depth milestones, outbound_link_click,
  newsletter_subscribed, workshop_signed_up, terminal_command,
  command_palette_opened/_action.
- cta_click listener moves from BaseLayout into posthog.astro; docs and
  env typings updated.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YNg67d2iyez7J9SBSegkNY